### PR TITLE
Feature/episerver 9 upgrade

### DIFF
--- a/ImageResizer.Plugins.EPiServerBlobReader.csproj
+++ b/ImageResizer.Plugins.EPiServerBlobReader.csproj
@@ -36,12 +36,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>packages\Castle.Core.3.2.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\Castle.Core.3.2.0\lib\net35\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Windsor, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>packages\Castle.Windsor.3.2.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\Castle.Windsor.3.2.0\lib\net40\Castle.Windsor.dll</HintPath>
     </Reference>
     <Reference Include="EPiServer, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -111,51 +111,52 @@
       <Private>True</Private>
       <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.XForms.dll</HintPath>
     </Reference>
-    <Reference Include="ImageResizer">
+    <Reference Include="ImageResizer, Version=3.4.2.549, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\ImageResizer.3.4.2\lib\ImageResizer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\Newtonsoft.Json.5.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=2.6.1.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\structuremap.2.6.1.0\lib\StructureMap.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.Helpers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>packages\Microsoft.AspNet.Mvc.4.0.20505.0\lib\net40\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\Microsoft.AspNet.Razor.2.0.20505.0\lib\net40\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
       <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -169,14 +170,14 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="ImageResizer.Plugins.EPiServerBlobReader.nuspec" />
-    <None Include="packages.config">
+    <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="ImageResizer.Plugins.EPiServerBlobReader.nuspec" />
     <Content Include="web.config.transform">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/ImageResizer.Plugins.EPiServerBlobReader.csproj
+++ b/ImageResizer.Plugins.EPiServerBlobReader.csproj
@@ -115,10 +115,6 @@
       <HintPath>packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=3.1.6.186, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <HintPath>packages\structuremap-signed.3.1.6.186\lib\net40\StructureMap.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="StructureMap.Net4, Version=3.1.6.186, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\structuremap-signed.3.1.6.186\lib\net40\StructureMap.Net4.dll</HintPath>
       <Private>True</Private>

--- a/ImageResizer.Plugins.EPiServerBlobReader.csproj
+++ b/ImageResizer.Plugins.EPiServerBlobReader.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ImageResizer.Plugins.EPiServerBlobReader</RootNamespace>
     <AssemblyName>ImageResizer.Plugins.EPiServerBlobReader</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">.\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/ImageResizer.Plugins.EPiServerBlobReader.csproj
+++ b/ImageResizer.Plugins.EPiServerBlobReader.csproj
@@ -43,73 +43,61 @@
       <HintPath>packages\Castle.Windsor.3.2.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ApplicationModules, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.ApplicationModules, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.ApplicationModules.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.ApplicationModules.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.BaseLibrary, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Configuration, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.Configuration.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.BaseLibrary.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Configuration, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Data, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.Data.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Data.Cache, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.Data.Cache.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.Data.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data.Cache, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Enterprise, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.Enterprise.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.Data.Cache.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Enterprise, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Events, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.Events.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.Enterprise.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Events, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Framework, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.Framework.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.Events.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.ImageLibrary, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.ImageLibrary.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ImageLibrary, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Licensing, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.Licensing.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.ImageLibrary.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Implementation, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.LinkAnalyzer, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.LinkAnalyzer.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.Implementation.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Licensing, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Shell, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.Framework.9.0.3\lib\net45\EPiServer.Shell.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.LinkAnalyzer, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.Web.WebControls, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.Web.WebControls.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.LinkAnalyzer.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Shell, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+    <Reference Include="EPiServer.XForms, Version=9.0.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>packages\EPiServer.CMS.Core.9.0.3\lib\net45\EPiServer.XForms.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\EPiServer.Framework.7.5.394.2\lib\net40\EPiServer.Shell.dll</HintPath>
-    </Reference>
-    <Reference Include="EPiServer.Web.WebControls, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.Web.WebControls.dll</HintPath>
-    </Reference>
-    <Reference Include="EPiServer.WorkflowFoundation, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.WorkflowFoundation.dll</HintPath>
-    </Reference>
-    <Reference Include="EPiServer.XForms, Version=7.5.394.2, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>packages\EPiServer.CMS.Core.7.5.394.2\lib\net40\EPiServer.XForms.dll</HintPath>
     </Reference>
     <Reference Include="ImageResizer, Version=3.4.2.549, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\ImageResizer.3.4.2\lib\ImageResizer.dll</HintPath>
@@ -124,38 +112,46 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StructureMap, Version=2.6.1.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
-      <HintPath>packages\structuremap.2.6.1.0\lib\StructureMap.dll</HintPath>
+    <Reference Include="StructureMap, Version=3.1.6.186, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>packages\structuremap-signed.3.1.6.186\lib\net40\StructureMap.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="StructureMap.Net4, Version=3.1.6.186, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\structuremap-signed.3.1.6.186\lib\net40\StructureMap.Net4.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="StructureMap.Web, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223, processorArchitecture=MSIL">
+      <HintPath>packages\structuremap.web-signed.3.1.6.186\lib\net40\StructureMap.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.Helpers.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.Mvc.4.0.20710.0\lib\net40\System.Web.Mvc.dll</HintPath>
       <Private>True</Private>
-      <HintPath>packages\Microsoft.AspNet.Mvc.4.0.20505.0\lib\net40\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.Razor.2.0.20505.0\lib\net40\System.Web.Razor.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.WebPages.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20505.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/app.config
+++ b/app.config
@@ -46,6 +46,34 @@
         <assemblyIdentity name="EPiServer.XForms" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.ApplicationModules" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.Data" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.Events" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.Framework" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.Licensing" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EPiServer.Shell" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/app.config
+++ b/app.config
@@ -49,6 +49,6 @@
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
 </configuration>

--- a/app.config
+++ b/app.config
@@ -1,82 +1,82 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="StructureMap" publicKeyToken="e60ad81abae3c223" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.6.1.0" newVersion="2.6.1.0"/>
+        <assemblyIdentity name="StructureMap" publicKeyToken="e60ad81abae3c223" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.1.0" newVersion="2.6.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.BaseLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.BaseLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Configuration" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Configuration" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Enterprise" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Enterprise" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.ImageLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.ImageLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Implementation" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Implementation" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.LinkAnalyzer" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.LinkAnalyzer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Web.WebControls" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Web.WebControls" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.WorkflowFoundation" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.WorkflowFoundation" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.XForms" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.XForms" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.ApplicationModules" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.ApplicationModules" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Data" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Data" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Events" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Events" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Framework" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Framework" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Licensing" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Licensing" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="EPiServer.Shell" publicKeyToken="8fe83dea738b45b7" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.5.394.2" newVersion="7.5.394.2"/>
+        <assemblyIdentity name="EPiServer.Shell" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.3.0" newVersion="9.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
 </configuration>

--- a/packages.config
+++ b/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.2.0"  />
-  <package id="Castle.Windsor" version="3.2.0" />
-  <package id="EPiServer.CMS.Core" version="7.5.394.2" />
-  <package id="EPiServer.Framework" version="7.5.394.2" />
+  <package id="Castle.Core" version="3.2.0" requireReinstallation="true" />
+  <package id="Castle.Windsor" version="3.2.0" requireReinstallation="true" />
+  <package id="EPiServer.CMS.Core" version="7.5.394.2" requireReinstallation="true" />
+  <package id="EPiServer.Framework" version="7.5.394.2" requireReinstallation="true" />
   <package id="ImageResizer" version="3.4.2" />
-  <package id="log4net" version="1.2.10" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.20505.0" />
-  <package id="Microsoft.AspNet.Razor" version="2.0.20505.0" />
-  <package id="Microsoft.AspNet.WebPages" version="2.0.20505.0" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
-  <package id="Newtonsoft.Json" version="5.0.1" />
+  <package id="log4net" version="1.2.10" requireReinstallation="true" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.20505.0" requireReinstallation="true" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20505.0" requireReinstallation="true" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.20505.0" requireReinstallation="true" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" requireReinstallation="true" />
+  <package id="Newtonsoft.Json" version="5.0.1" requireReinstallation="true" />
   <package id="structuremap" version="2.6.1.0" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -2,14 +2,16 @@
 <packages>
   <package id="Castle.Core" version="3.2.0" targetFramework="net452" />
   <package id="Castle.Windsor" version="3.2.0" targetFramework="net452" />
-  <package id="EPiServer.CMS.Core" version="7.5.394.2" targetFramework="net452" />
-  <package id="EPiServer.Framework" version="7.5.394.2" targetFramework="net452" />
+  <package id="EPiServer.CMS.Core" version="9.0.3" targetFramework="net452" />
+  <package id="EPiServer.Framework" version="9.0.3" targetFramework="net452" />
   <package id="ImageResizer" version="3.4.2" targetFramework="net452" />
   <package id="log4net" version="1.2.10" targetFramework="net452" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.20505.0" targetFramework="net452" />
-  <package id="Microsoft.AspNet.Razor" version="2.0.20505.0" targetFramework="net452" />
-  <package id="Microsoft.AspNet.WebPages" version="2.0.20505.0" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net452" />
   <package id="structuremap" version="2.6.1.0" targetFramework="net452" />
+  <package id="structuremap.web-signed" version="3.1.6.186" targetFramework="net452" />
+  <package id="structuremap-signed" version="3.1.6.186" targetFramework="net452" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -11,7 +11,6 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net452" />
-  <package id="structuremap" version="2.6.1.0" targetFramework="net452" />
   <package id="structuremap.web-signed" version="3.1.6.186" targetFramework="net452" />
   <package id="structuremap-signed" version="3.1.6.186" targetFramework="net452" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.2.0" requireReinstallation="true" />
-  <package id="Castle.Windsor" version="3.2.0" requireReinstallation="true" />
-  <package id="EPiServer.CMS.Core" version="7.5.394.2" requireReinstallation="true" />
-  <package id="EPiServer.Framework" version="7.5.394.2" requireReinstallation="true" />
-  <package id="ImageResizer" version="3.4.2" />
-  <package id="log4net" version="1.2.10" requireReinstallation="true" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.20505.0" requireReinstallation="true" />
-  <package id="Microsoft.AspNet.Razor" version="2.0.20505.0" requireReinstallation="true" />
-  <package id="Microsoft.AspNet.WebPages" version="2.0.20505.0" requireReinstallation="true" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" requireReinstallation="true" />
-  <package id="Newtonsoft.Json" version="5.0.1" requireReinstallation="true" />
-  <package id="structuremap" version="2.6.1.0" />
+  <package id="Castle.Core" version="3.2.0" targetFramework="net452" />
+  <package id="Castle.Windsor" version="3.2.0" targetFramework="net452" />
+  <package id="EPiServer.CMS.Core" version="7.5.394.2" targetFramework="net452" />
+  <package id="EPiServer.Framework" version="7.5.394.2" targetFramework="net452" />
+  <package id="ImageResizer" version="3.4.2" targetFramework="net452" />
+  <package id="log4net" version="1.2.10" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.20505.0" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20505.0" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.20505.0" targetFramework="net452" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net452" />
+  <package id="structuremap" version="2.6.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Upgrades EPiServer dependency to make plugin work with EPiServer 9. Upgrades target framework to 4.5.2 as EPiServer 9 has no build for .NET 4.