### PR TITLE
Fixed: cache refresh problem and ImageCorruptedException while downloading non-image files

### DIFF
--- a/EPiServerBlobFile.cs
+++ b/EPiServerBlobFile.cs
@@ -68,7 +68,7 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
                     var trackable = Content as IChangeTrackable;
                     if (trackable != null)
                     {
-                        return trackable.Changed.ToUniversalTime();
+                        return trackable.Saved.ToUniversalTime();
                     }
                 }
                 return DateTime.MinValue.ToUniversalTime();

--- a/EPiServerBlobReaderPlugin.cs
+++ b/EPiServerBlobReaderPlugin.cs
@@ -70,8 +70,6 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
                 return;
             }
 
-            Config.Current.Pipeline.SkipFileTypeCheck = true;
-
             var previewOrEditMode = RequestSegmentContext.CurrentContextMode == ContextMode.Edit || RequestSegmentContext.CurrentContextMode == ContextMode.Preview;
 
             // Disable cache if editing or previewing


### PR DESCRIPTION
Fixed two issues:
- IChangeTrackable.Changed won't be updated unless the editor checks "update modification date". The result is that the image gets updated but an old version is still cached by ImageResizer. It's better to use the Saved property which will be updated whenever the file is changed. Thanks to @dratini for this.

- Downloading any file that isn't an image causes ImageResizer.ImageCorruptedException to be thrown because of the SkipFileTypeCheck = true; in EPiServerBlobReaderPlugin.cs. I tested and everything seems to be working fine without it, so I don't see a reason for keeping it.