### PR TITLE
Fix thumbnail generation when ImageResizer 4 used

### DIFF
--- a/EPiServerBlobReaderPlugin.cs
+++ b/EPiServerBlobReaderPlugin.cs
@@ -55,6 +55,9 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
 
         private void OnPostAuthorizeRequestStart(IHttpModule sender, HttpContext context)
         {
+            if (context.Request.Url.ToString().Contains("Thumbnail?epieditmode"))
+                return;
+                
             var absolutePath = CleanEditModePath(context.Request.Url.AbsolutePath);
             var resolvedContent = __urlResolver.Route(new UrlBuilder(absolutePath));
 


### PR DESCRIPTION
Fix problem described in http://world.episerver.com/forum/developer-forum/-EPiServer-75-CMS/Thread-Container/2016/1/thumbnails-in-assets-pane-are-really-full-size-images/