### PR TITLE
Proposed fix for draft version image loading problem in edit mode.

### DIFF
--- a/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobReaderPlugin.cs
+++ b/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobReaderPlugin.cs
@@ -58,20 +58,20 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
             // Thumbnail URLs should not be modified, e.g. 
             // http://host.com/ui/CMS/Content/contentassets/0c51b2fa1f464956aab221c6ecc21804/file.jpg,,82777/Thumbnail?epieditmode=False?1470652477313
 
-            if (PipelineIsUsingResizer())
+            var pipelineConfig = Config.Current.Pipeline;
+
+            if (PipelineIsUsingResizer(pipelineConfig))
             {
                 var fixedUrl = PathRegex.Replace(context.Request.Url.AbsolutePath, string.Empty);
-                Config.Current.Pipeline.PreRewritePath = fixedUrl;
+                pipelineConfig.PreRewritePath = fixedUrl;
             }
         }
 
-        private bool PipelineIsUsingResizer()
+        private bool PipelineIsUsingResizer(PipelineConfig config)
         {
-            var pipeline = Config.Current.Pipeline;
-
-            foreach (string key in pipeline.ModifiedQueryString.Keys)
+            foreach (string key in config.ModifiedQueryString.Keys)
             {
-                if (pipeline.SupportedQuerystringKeys.Contains(key))
+                if (config.SupportedQuerystringKeys.Contains(key))
                 {
                     return true;
                 }

--- a/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobReaderPlugin.cs
+++ b/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobReaderPlugin.cs
@@ -11,7 +11,7 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
     /// </summary>
     public class EPiServerBlobReaderPlugin : IVirtualImageProvider, IPlugin
     {
-        private static readonly Regex PathRegex = new Regex(@",,\d+", RegexOptions.Compiled);
+        private static readonly Regex PathRegex = new Regex(@",,[\d_]+", RegexOptions.Compiled);
 
         public IPlugin Install(Config config)
         {
@@ -58,8 +58,26 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
             // Thumbnail URLs should not be modified, e.g. 
             // http://host.com/ui/CMS/Content/contentassets/0c51b2fa1f464956aab221c6ecc21804/file.jpg,,82777/Thumbnail?epieditmode=False?1470652477313
 
-            var fixedUrl = PathRegex.Replace(context.Request.Url.AbsolutePath, string.Empty);
-            Config.Current.Pipeline.PreRewritePath = fixedUrl;
+            if (PipelineIsUsingResizer())
+            {
+                var fixedUrl = PathRegex.Replace(context.Request.Url.AbsolutePath, string.Empty);
+                Config.Current.Pipeline.PreRewritePath = fixedUrl;
+            }
+        }
+
+        private bool PipelineIsUsingResizer()
+        {
+            var pipeline = Config.Current.Pipeline;
+
+            foreach (string key in pipeline.ModifiedQueryString.Keys)
+            {
+                if (pipeline.SupportedQuerystringKeys.Contains(key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
This change adjusts the PathRegex to also remove WorkId from the path of the image inside edit mode.
Previous match ',,28.jpg' will now also match ',,28_125.jpg'.

Also found that when adjusting PreRewritePath an image, having WorkId set, not using any ImageResizer query modifiers would fail to load, so I've added a check if the resizer is going to be used before modifying the url.