### PR TITLE
Enable async ImageResizer pipeline

### DIFF
--- a/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobFile.cs
+++ b/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobFile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.IO;
+using System.Threading.Tasks;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.Framework.Blobs;
@@ -12,7 +13,7 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
 {
     // Original code (or at least as much as left from it):
     // http://world.episerver.com/Code/Martin-Pickering/ImageResizingNet-integration-for-CMS75/
-    public class EPiServerBlobFile : IVirtualFileWithModifiedDate
+    public class EPiServerBlobFile : IVirtualFileWithModifiedDate, IVirtualFileAsync
     {
         private readonly UrlResolver _urlResolver;
         private Blob _blob;
@@ -53,6 +54,10 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
         public bool BlobExists => Content != null;
 
         public string VirtualPath { get; }
+        public Task<Stream> OpenAsync()
+        {
+            return Task.FromResult(Blob?.OpenRead());
+        }
 
         public DateTime ModifiedDateUTC
         {

--- a/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobReaderPlugin.cs
+++ b/src/ImageResizer.Plugins.EPiServerBlobReader/EPiServerBlobReaderPlugin.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Web;
 using ImageResizer.Configuration;
 
@@ -9,7 +10,7 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
     ///     Copyright:
     ///     https://raw.githubusercontent.com/Igelkottegrodan/ImageResizer.Plugins.EPiServerBlobPlugin/master/ImageResizer.Plugins.EPiServerBlobPlugin/EPiServerBlobPlugin.cs
     /// </summary>
-    public class EPiServerBlobReaderPlugin : IVirtualImageProvider, IPlugin
+    public class EPiServerBlobReaderPlugin : IVirtualImageProvider, IVirtualImageProviderAsync, IPlugin
     {
         private static readonly Regex PathRegex = new Regex(@",,[\d_]+", RegexOptions.Compiled);
 
@@ -78,6 +79,19 @@ namespace ImageResizer.Plugins.EPiServerBlobReader
             }
 
             return false;
+        }
+
+        public Task<bool> FileExistsAsync(string virtualPath, NameValueCollection queryString)
+        {
+            var blobImage = GetBlobFile(virtualPath, queryString);
+            var exists = blobImage != null && blobImage.BlobExists;
+            return Task.FromResult(exists);
+        }
+
+        public Task<IVirtualFileAsync> GetFileAsync(string virtualPath, NameValueCollection queryString)
+        {
+            IVirtualFileAsync blobImage = GetBlobFile(virtualPath, queryString);
+            return Task.FromResult(blobImage);
         }
     }
 }


### PR DESCRIPTION
Support the async interfaces from ImageResizer so that it is possible to use the plugin with the ImageResizer.AsyncInterceptModule